### PR TITLE
Update nbf.c for loopback

### DIFF
--- a/XDMA/linux-kernel/tools/nbf.c
+++ b/XDMA/linux-kernel/tools/nbf.c
@@ -320,7 +320,11 @@ int main(int argc, char **argv)
                         *load_addr_ptr = htoll((uint32_t)(dequeue(queue)));
                         *load_addr_ptr = htoll((uint32_t)0x00000000);
                     }
-                }
+                } else {
+		  // Return 0 for spurious requests
+		  *load_addr_ptr = htoll((uint32_t)0x00000000);
+		  *load_addr_ptr = htoll((uint32_t)0x00000000);
+		}
             }
         }
         


### PR DESCRIPTION
Sometimes, speculative requests escape BlackParrot and want a response.  For these, a default value of 0 will prevent the system from hanging